### PR TITLE
Fix cluster robust standard errors

### DIFF
--- a/R/rdmulti/R/rdmc.R
+++ b/R/rdmulti/R/rdmc.R
@@ -226,6 +226,12 @@ rdmc <- function(Y,X,C,fuzzy=NULL,derivvec=NULL,pooled_opt=NULL,verbose=FALSE,
       covs_aux <- NULL
     }
 
+    if (!is.null(cluster)){
+      cc <- cluster[abs(C-c)<=.Machine$double.eps]
+    } else {
+      cc <- NULL
+    }
+
     rdr.tmp <- try(rdrobust::rdrobust(yc,xc,
                                       fuzzy=fuzzy,
                                       deriv=derivvec[count],
@@ -247,7 +253,7 @@ rdmc <- function(Y,X,C,fuzzy=NULL,derivvec=NULL,pooled_opt=NULL,verbose=FALSE,
                                       stdvars=stdvarsvec[count],
                                       vce=vcevec[count],
                                       nnmatch=nnmatchvec[count],
-                                      cluster=cluster,
+                                      cluster=cc,
                                       level=level),
                    silent=TRUE)
 

--- a/R/rdmulti/R/rdms.R
+++ b/R/rdmulti/R/rdms.R
@@ -202,6 +202,12 @@ rdms <- function(Y,X,C,X2=NULL,zvar=NULL,C2=NULL,rangemat=NULL,xnorm=NULL,
         covs_aux <- NULL
       }
 
+      if (!is.null(cluster)){
+        cc <- cluster[xc>=Rc[c,1] & xc<=Rc[c,2]]
+      } else {
+        cc <- NULL
+      }
+
       rdr.tmp <- rdrobust::rdrobust(yc,xc,
                                    fuzzy=fuzzy,
                                    deriv=derivvec[c],
@@ -223,7 +229,7 @@ rdms <- function(Y,X,C,X2=NULL,zvar=NULL,C2=NULL,rangemat=NULL,xnorm=NULL,
                                    stdvars=stdvarsvec[c],
                                    vce=vcevec[c],
                                    nnmatch=nnmatchvec[c],
-                                   cluster=cluster,
+                                   cluster=cc,
                                    level=level)
 
       B[1,c] <- rdr.tmp$Estimate[2]
@@ -270,6 +276,12 @@ rdms <- function(Y,X,C,X2=NULL,zvar=NULL,C2=NULL,rangemat=NULL,xnorm=NULL,
         covs_aux <- NULL
       }
 
+      if (!is.null(cluster)){
+        cc <- cluster[xc>=rangemat[c,1] & xc<=rangemat[c,2]]
+      } else {
+        cc <- NULL
+      }
+
       rdr.tmp <- rdrobust::rdrobust(yc,xc,
                                    fuzzy=fuzzy,
                                    deriv=derivvec[c],
@@ -291,7 +303,7 @@ rdms <- function(Y,X,C,X2=NULL,zvar=NULL,C2=NULL,rangemat=NULL,xnorm=NULL,
                                    stdvars=stdvarsvec[c],
                                    vce=vcevec[c],
                                    nnmatch=nnmatchvec[c],
-                                   cluster=cluster,
+                                   cluster=cc,
                                    level=level)
 
       B[1,c] <- rdr.tmp$Estimate[2]


### PR DESCRIPTION
Fix such that cluster ID variable is subsetted in the same way Y and X is if cluster is not null